### PR TITLE
GitHub ribbon now doesn't toggle a horizontal scrollbar

### DIFF
--- a/views/app.sass
+++ b/views/app.sass
@@ -114,7 +114,7 @@ a
   $color: #720
   background-color: $color
   overflow: hidden
-  position: absolute
+  position: fixed
   right: -3em
   top: 2.5em
   @include transform-rotate(45deg)


### PR DESCRIPTION
Use "position: fixed" to avoid github ribbon from horizontally overflowing the body

Using as an excuse to test cloud9 IDE workflow and github pull requests =D
