### PR TITLE
Adding comment placeholders

### DIFF
--- a/views/app.coffee
+++ b/views/app.coffee
@@ -52,7 +52,6 @@ class ToWatchView extends Backbone.View
 
   updateCommentOnEnter:(event)->
     if event.keyCode == 13
-      @updateComment()
       @$('.comment').blur()
 
   delete:->

--- a/views/app.coffee
+++ b/views/app.coffee
@@ -14,6 +14,7 @@ class ToWatchView extends Backbone.View
     'click :checkbox':        'toggleWatched'
     'blur .comment':          'updateComment'
     'keydown .comment':       'updateCommentOnEnter'
+    'focus .comment':         'removeCommentPlaceholder'
     'click .delete':          'delete'
 
   initialize:->
@@ -40,6 +41,7 @@ class ToWatchView extends Backbone.View
     @$('.title').text @model.get('title') || @model.get('link')
     @$('.title').prop 'href', @model.get('link')
     @$('.comment').text @model.get 'comment'
+    @$('.comment').addClass 'empty-comment' unless @model.get 'comment'
     @
 
   toggleWatched:->
@@ -49,10 +51,15 @@ class ToWatchView extends Backbone.View
   updateComment:->
     @model.set comment: @$('.comment').text()
     @model.save()
+    @$('.comment').addClass 'empty-comment' unless @$('.comment').text()
 
   updateCommentOnEnter:(event)->
+    @$(event.target).removeClass 'empty-comment'
     if event.keyCode == 13
       @$('.comment').blur()
+
+  removeCommentPlaceholder:->
+    @$('.comment').removeClass 'empty-comment' if @$('.comment').text()
 
   delete:->
     @model.destroy()

--- a/views/app.sass
+++ b/views/app.sass
@@ -82,6 +82,9 @@ a
     //border-bottom: 1px dashed $front-color
   .comment
     margin-top: 5px
+  .empty-comment:before
+    content: 'add comment...'
+    color: lightGray
   .title, .comment
     margin-left: 25px
   .delete


### PR DESCRIPTION
If there's no placeholder, there is no way for users to add a comment after creating the video and not writting one (IMHO placeholders look cool too :P)

To reproduce:
- Add a video to the list
- Don't put a comment
- Focus anywhere in the page (but the comment)
- Try to add a comment

Expected result: you should be able to add a comment
Result: (at least, in Firefox 10.0.2) You can't click on the place where comments are supposed to be
